### PR TITLE
feat: Read messages without expecting some delimiters

### DIFF
--- a/cmd/chat-server/internal/helper_test.go
+++ b/cmd/chat-server/internal/helper_test.go
@@ -30,8 +30,7 @@ func assertConnectionIsClosed(t *testing.T, conn net.Conn) {
 
 	oneByte := make([]byte, 1)
 	_, err := conn.Read(oneByte)
-
-	assert.Equal(t, io.EOF, err)
+	assert.Equal(t, io.EOF, err, "Actual err: %v", err)
 }
 
 func assertConnectionIsStillOpen(t *testing.T, conn net.Conn) {

--- a/cmd/chat-server/internal/server_test.go
+++ b/cmd/chat-server/internal/server_test.go
@@ -2,9 +2,9 @@ package internal
 
 import (
 	"context"
-	"fmt"
 	"net"
 	"os"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -45,27 +45,6 @@ func TestUnit_RunServer_WhenServerCloses_ExpectConnectionToBeClosed(t *testing.T
 	cancel()
 	wg.Wait()
 	assertConnectionIsClosed(t, conn)
-}
-
-func TestUnit_RunServer_WhenSendingGarbage_ExpectConnectionToBeClosed(t *testing.T) {
-	cancellable, cancel := context.WithCancel(context.Background())
-	config := newTestConfig(7102)
-
-	wg := asyncRunServer(t, config, cancellable)
-
-	conn, err := net.Dial("tcp", ":7102")
-	assert.Nil(t, err, "Actual err: %v", err)
-	_, err = conn.Write(sampleData)
-	assert.Nil(t, err, "Actual err: %v", err)
-
-	// Wait long enough for the read timeout to be reached and for
-	// the connection to be closed
-	time.Sleep(2 * time.Second)
-
-	assertConnectionIsClosed(t, conn)
-
-	cancel()
-	wg.Wait()
 }
 
 func TestUnit_RunServer_OnConnect_ExpectOthersAreNotified(t *testing.T) {
@@ -154,7 +133,6 @@ func TestUnit_RunServer_WhenSendingMessageToClient_ExpectOnlyItReceivesIt(t *tes
 	msg = messages.NewDirectMessage(dummyIdForClient1, clientId2, "Hello, client 2")
 	out, err := messages.Encode(msg)
 
-	fmt.Printf("sending %d byte(s) to server: \"%s\"\n", len(out), string(out))
 	assert.Nil(t, err, "Actual err: %v", err)
 	n, err := conn1.Write(out)
 	assert.Nil(t, err, "Actual err: %v", err)
@@ -172,6 +150,54 @@ func TestUnit_RunServer_WhenSendingMessageToClient_ExpectOnlyItReceivesIt(t *tes
 	assert.Equal(t, dummyIdForClient1, actual.Emitter)
 	assert.Equal(t, clientId2, actual.Receiver)
 	assert.Equal(t, "Hello, client 2", actual.Content)
+
+	cancel()
+	wg.Wait()
+}
+
+func TestUnit_RunServer_WhenSendingGarbage_ExpectConnectionToStayOpen(t *testing.T) {
+	cancellable, cancel := context.WithCancel(context.Background())
+	config := newTestConfig(7102)
+
+	wg := asyncRunServer(t, config, cancellable)
+
+	conn, err := net.Dial("tcp", ":7102")
+	assert.Nil(t, err, "Actual err: %v", err)
+	_, err = conn.Write([]byte("garbage"))
+	assert.Nil(t, err, "Actual err: %v", err)
+
+	// Wait long enough for the read timeout to expire and connection
+	// to be effectively closed if it does terminate.
+	time.Sleep(2 * time.Second)
+
+	assertConnectionIsStillOpen(t, conn)
+
+	cancel()
+	wg.Wait()
+}
+
+func TestUnit_RunServer_WhenClientIsSendingTooMuchGarbage_ExpectDisconnected(t *testing.T) {
+	cancellable, cancel := context.WithCancel(context.Background())
+	config := newTestConfig(7106)
+
+	wg := asyncRunServer(t, config, cancellable)
+
+	conn, err := net.Dial("tcp", ":7106")
+	assert.Nil(t, err, "Actual err: %v", err)
+
+	time.Sleep(reasonableTimeForConnectionToBeProcessed)
+
+	// Generate a garbage string that can't be interpreted as a valid message.
+	out := []byte(strings.Repeat("abc123def456ghi789kl", 60))
+
+	n, err := conn.Write(out)
+	assert.Nil(t, err, "Actual err: %v", err)
+	assert.Equal(t, len(out), n)
+
+	// Wait long enough for the connection to be terminated.
+	time.Sleep(200 * time.Millisecond)
+
+	assertConnectionIsClosed(t, conn)
 
 	cancel()
 	wg.Wait()

--- a/pkg/clients/callbacks.go
+++ b/pkg/clients/callbacks.go
@@ -12,8 +12,9 @@ type OnConnect func(id uuid.UUID, conn net.Conn) bool
 // The connection will automatically be closed after this callback is triggered.
 type OnDisconnect func(id uuid.UUID)
 
-// The return value should indicate whether or not the connection should stay open.
-type OnReadData func(id uuid.UUID, data []byte) bool
+// The return value should indicate whether or not the connection should stay open
+// and how many bytes were processed.
+type OnReadData func(id uuid.UUID, data []byte) (int, bool)
 
 // The connection will automatically be closed after this callback is triggered.
 type OnReadError func(id uuid.UUID, err error)
@@ -38,9 +39,9 @@ func (c Callbacks) OnDisconnect(id uuid.UUID) {
 	}
 }
 
-func (c Callbacks) OnReadData(id uuid.UUID, data []byte) bool {
+func (c Callbacks) OnReadData(id uuid.UUID, data []byte) (int, bool) {
 	if c.ReadDataCallback == nil {
-		return true
+		return 0, true
 	}
 	return c.ReadDataCallback(id, data)
 }

--- a/pkg/clients/callbacks_test.go
+++ b/pkg/clients/callbacks_test.go
@@ -30,13 +30,59 @@ func TestUnit_Callbacks_OnConnect_WhenUnset_ExpectConnectionAccepted(t *testing.
 	assert.True(t, actual)
 }
 
-func TestUnit_Callbacks_OnDisonnect_WhenUnset_ExpectNoFatalFailure(t *testing.T) {
+func TestUnit_Callbacks_OnConnect_ExpectCallbackToBeCalled(t *testing.T) {
+	var called int
+	callbacks := Callbacks{
+		ConnectCallback: func(id uuid.UUID, conn net.Conn) bool {
+			called++
+			return false
+		},
+	}
+
+	var conn net.Conn
+	callbacks.OnConnect(uuid.New(), conn)
+
+	assert.Equal(t, 1, called)
+}
+
+func TestUnit_Callbacks_OnConnect_ExpectCallbackValueToBeReturned(t *testing.T) {
+	var conn net.Conn
+
+	callbacks := Callbacks{
+		ConnectCallback: func(id uuid.UUID, conn net.Conn) bool {
+			return false
+		},
+	}
+	actual := callbacks.OnConnect(uuid.New(), conn)
+	assert.False(t, actual)
+
+	callbacks.ConnectCallback = func(id uuid.UUID, conn net.Conn) bool {
+		return true
+	}
+	actual = callbacks.OnConnect(uuid.New(), conn)
+	assert.True(t, actual)
+}
+
+func TestUnit_Callbacks_OnDisconnect_WhenUnset_ExpectNoFatalFailure(t *testing.T) {
 	var callbacks Callbacks
 
 	callback := func() {
 		callbacks.OnDisconnect(uuid.New())
 	}
 	assert.NotPanics(t, callback)
+}
+
+func TestUnit_Callbacks_OnDisconnect_ExpectCallbackToBeCalled(t *testing.T) {
+	var called int
+	callbacks := Callbacks{
+		DisconnectCallback: func(id uuid.UUID) {
+			called++
+		},
+	}
+
+	callbacks.OnDisconnect(uuid.New())
+
+	assert.Equal(t, 1, called)
 }
 
 func TestUnit_Callbacks_OnReadData_WhenUnset_ExpectNoFatalFailure(t *testing.T) {
@@ -51,9 +97,44 @@ func TestUnit_Callbacks_OnReadData_WhenUnset_ExpectNoFatalFailure(t *testing.T) 
 func TestUnit_Callbacks_OnReadData_WhenUnset_ExpectConnectionStaysOpen(t *testing.T) {
 	var callbacks Callbacks
 
-	actual := callbacks.OnReadData(uuid.New(), []byte{})
+	_, actual := callbacks.OnReadData(uuid.New(), []byte{})
 
 	assert.True(t, actual)
+}
+
+func TestUnit_Callbacks_OnReadData_WhenUnset_ExpectNoBytesProcessed(t *testing.T) {
+	var callbacks Callbacks
+
+	actual, _ := callbacks.OnReadData(uuid.New(), []byte{})
+
+	assert.Equal(t, 0, actual)
+}
+
+func TestUnit_Callbacks_OnReadData_ExpectCallbackToBeCalled(t *testing.T) {
+	var called int
+	callbacks := Callbacks{
+		ReadDataCallback: func(id uuid.UUID, data []byte) (int, bool) {
+			called++
+			return 0, true
+		},
+	}
+
+	callbacks.OnReadData(uuid.New(), []byte{})
+
+	assert.Equal(t, 1, called)
+}
+
+func TestUnit_Callbacks_OnReadData_ExpectCallbackValueToBeReturned(t *testing.T) {
+	callbacks := Callbacks{
+		ReadDataCallback: func(id uuid.UUID, data []byte) (int, bool) {
+			return 14, false
+		},
+	}
+
+	processed, keepAlive := callbacks.OnReadData(uuid.New(), []byte{})
+
+	assert.Equal(t, 14, processed)
+	assert.False(t, keepAlive)
 }
 
 func TestUnit_Callbacks_OnReadError_WhenUnset_ExpectNoFatalFailure(t *testing.T) {
@@ -63,4 +144,17 @@ func TestUnit_Callbacks_OnReadError_WhenUnset_ExpectNoFatalFailure(t *testing.T)
 		callbacks.OnReadError(uuid.New(), errSample)
 	}
 	assert.NotPanics(t, callback)
+}
+
+func TestUnit_Callbacks_OnReadError_ExpectCallbackToBeCalled(t *testing.T) {
+	var called int
+	callbacks := Callbacks{
+		ReadErrorCallback: func(id uuid.UUID, err error) {
+			called++
+		},
+	}
+
+	callbacks.OnReadError(uuid.New(), errSample)
+
+	assert.Equal(t, 1, called)
 }

--- a/pkg/connection/callbacks.go
+++ b/pkg/connection/callbacks.go
@@ -4,28 +4,32 @@ import "github.com/google/uuid"
 
 type OnDisconnect func(id uuid.UUID)
 type OnReadError func(id uuid.UUID, err error)
-type OnReadData func(id uuid.UUID, data []byte)
+
+// OnReadData is a callback that is called when data is read from a connection.
+// The return value indicates how many bytes were processed.
+type OnReadData func(id uuid.UUID, data []byte) int
 
 type Callbacks struct {
-	DisconnectCallbacks []OnDisconnect
-	ReadErrorCallbacks  []OnReadError
-	ReadDataCallbacks   []OnReadData
+	DisconnectCallback OnDisconnect
+	ReadErrorCallback  OnReadError
+	ReadDataCallback   OnReadData
 }
 
 func (c Callbacks) OnDisconnect(id uuid.UUID) {
-	for _, callback := range c.DisconnectCallbacks {
-		callback(id)
+	if c.DisconnectCallback != nil {
+		c.DisconnectCallback(id)
 	}
 }
 
 func (c Callbacks) OnReadError(id uuid.UUID, err error) {
-	for _, callback := range c.ReadErrorCallbacks {
-		callback(id, err)
+	if c.ReadErrorCallback != nil {
+		c.ReadErrorCallback(id, err)
 	}
 }
 
-func (c Callbacks) OnReadData(id uuid.UUID, data []byte) {
-	for _, callback := range c.ReadDataCallbacks {
-		callback(id, data)
+func (c Callbacks) OnReadData(id uuid.UUID, data []byte) int {
+	if c.ReadDataCallback == nil {
+		return 0
 	}
+	return c.ReadDataCallback(id, data)
 }

--- a/pkg/connection/callbacks_test.go
+++ b/pkg/connection/callbacks_test.go
@@ -15,25 +15,18 @@ func TestUnit_Callbacks_OnDisconnect_WhenUnset_ExpectNoFatalFailure(t *testing.T
 	}
 	assert.NotPanics(t, callback)
 }
-
-func TestUnit_Callbacks_OnDisconnect_CallsAllCallbacks(t *testing.T) {
-	var called1, called2 int
+func TestUnit_Callbacks_OnDisconnect_ExpectCallbackIsCalled(t *testing.T) {
+	var called int
 
 	callbacks := Callbacks{
-		DisconnectCallbacks: []OnDisconnect{
-			func(id uuid.UUID) {
-				called1++
-			},
-			func(id uuid.UUID) {
-				called2++
-			},
+		DisconnectCallback: func(id uuid.UUID) {
+			called++
 		},
 	}
 
 	callbacks.OnDisconnect(uuid.New())
 
-	assert.Equal(t, 1, called1)
-	assert.Equal(t, 1, called2)
+	assert.Equal(t, 1, called)
 }
 
 func TestUnit_Callbacks_OnReadError_WhenUnset_ExpectNoFatalFailure(t *testing.T) {
@@ -45,24 +38,18 @@ func TestUnit_Callbacks_OnReadError_WhenUnset_ExpectNoFatalFailure(t *testing.T)
 	assert.NotPanics(t, callback)
 }
 
-func TestUnit_ConnectionCallbacks_OnReadError_CallsAllCallbacks(t *testing.T) {
-	var called1, called2 int
+func TestUnit_Callbacks_OnReadError_ExpectCallbackIsCalled(t *testing.T) {
+	var called int
 
 	callbacks := Callbacks{
-		ReadErrorCallbacks: []OnReadError{
-			func(id uuid.UUID, err error) {
-				called1++
-			},
-			func(id uuid.UUID, err error) {
-				called2++
-			},
+		ReadErrorCallback: func(id uuid.UUID, err error) {
+			called++
 		},
 	}
 
 	callbacks.OnReadError(uuid.New(), errSample)
 
-	assert.Equal(t, 1, called1)
-	assert.Equal(t, 1, called2)
+	assert.Equal(t, 1, called)
 }
 
 func TestUnit_Callbacks_OnReadData_WhenUnset_ExpectNoFatalFailure(t *testing.T) {
@@ -74,22 +61,26 @@ func TestUnit_Callbacks_OnReadData_WhenUnset_ExpectNoFatalFailure(t *testing.T) 
 	assert.NotPanics(t, callback)
 }
 
-func TestUnit_ConnectionCallbacks_OnReadData_CallsAllCallbacks(t *testing.T) {
-	var called1, called2 int
+func TestUnit_Callbacks_OnReadData_ExpectCallbackIsCalled(t *testing.T) {
+	var called int
 
 	callbacks := Callbacks{
-		ReadDataCallbacks: []OnReadData{
-			func(id uuid.UUID, data []byte) {
-				called1++
-			},
-			func(id uuid.UUID, data []byte) {
-				called2++
-			},
+		ReadDataCallback: func(id uuid.UUID, data []byte) int {
+			called++
+			return 0
 		},
 	}
 
-	callbacks.OnReadData(uuid.New(), []byte{})
+	processed := callbacks.OnReadData(uuid.New(), []byte{})
 
-	assert.Equal(t, 1, called1)
-	assert.Equal(t, 1, called2)
+	assert.Equal(t, 1, called)
+	assert.Equal(t, 0, processed)
+}
+
+func TestUnit_Callbacks_OnReadData_WhenUnset_ExpectNoBytesProcessed(t *testing.T) {
+	var callbacks Callbacks
+
+	processed := callbacks.OnReadData(sampleUuid, []byte{})
+
+	assert.Equal(t, 0, processed)
 }

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -16,6 +16,7 @@ const readSizeInBytes = 512
 
 type connection interface {
 	Read() ([]byte, error)
+	DiscardBytes(n int)
 	Write(b []byte) (int, error)
 	Close() error
 }
@@ -76,6 +77,7 @@ func (c *connectionImpl) Read() ([]byte, error) {
 	}
 
 	received, readErr := c.conn.Read(c.tmp)
+
 	if err := c.accumulateIncomingData(c.tmp[:received]); err != nil {
 		return []byte{}, err
 	}
@@ -87,6 +89,14 @@ func (c *connectionImpl) Read() ([]byte, error) {
 	}
 
 	return c.data, readErr
+}
+
+func (c *connectionImpl) DiscardBytes(n int) {
+	if n >= len(c.data) {
+		c.data = []byte{}
+	} else {
+		c.data = c.data[n:]
+	}
 }
 
 func (c *connectionImpl) Write(data []byte) (int, error) {

--- a/pkg/connection/listener_test.go
+++ b/pkg/connection/listener_test.go
@@ -69,10 +69,9 @@ func TestUnit_Listener_WhenDataReceived_ExpectCallbackNotified(t *testing.T) {
 	opts := ListenerOptions{
 		ReadTimeout: sampleReadTimeout,
 		Callbacks: Callbacks{
-			ReadDataCallbacks: []OnReadData{
-				func(id uuid.UUID, data []byte) {
-					called++
-				},
+			ReadDataCallback: func(id uuid.UUID, data []byte) int {
+				called++
+				return 0
 			},
 		},
 	}
@@ -94,10 +93,9 @@ func TestUnit_Listener_WhenDataReceived_ExpectCallbackReceivesCorrectId(t *testi
 	opts := ListenerOptions{
 		ReadTimeout: sampleReadTimeout,
 		Callbacks: Callbacks{
-			ReadDataCallbacks: []OnReadData{
-				func(id uuid.UUID, data []byte) {
-					actualId = id
-				},
+			ReadDataCallback: func(id uuid.UUID, data []byte) int {
+				actualId = id
+				return 0
 			},
 		},
 	}
@@ -119,10 +117,9 @@ func TestUnit_Listener_WhenDataReceived_ExpectCallbackReceivesCorrectData(t *tes
 	opts := ListenerOptions{
 		ReadTimeout: sampleReadTimeout,
 		Callbacks: Callbacks{
-			ReadDataCallbacks: []OnReadData{
-				func(id uuid.UUID, data []byte) {
-					actualData = data
-				},
+			ReadDataCallback: func(id uuid.UUID, data []byte) int {
+				actualData = data
+				return 0
 			},
 		},
 	}
@@ -143,10 +140,8 @@ func TestUnit_Listener_WhenClientDisconnects_ExpectCallbackNotified(t *testing.T
 	var called int
 	opts := ListenerOptions{
 		Callbacks: Callbacks{
-			DisconnectCallbacks: []OnDisconnect{
-				func(id uuid.UUID) {
-					called++
-				},
+			DisconnectCallback: func(id uuid.UUID) {
+				called++
 			},
 		},
 	}
@@ -165,10 +160,8 @@ func TestUnit_Listener_WhenClientDisconnects_ExpectCallbackReceivesCorrectId(t *
 	var actualId uuid.UUID
 	opts := ListenerOptions{
 		Callbacks: Callbacks{
-			DisconnectCallbacks: []OnDisconnect{
-				func(id uuid.UUID) {
-					actualId = id
-				},
+			DisconnectCallback: func(id uuid.UUID) {
+				actualId = id
 			},
 		},
 	}
@@ -189,16 +182,12 @@ func TestUnit_Listener_WhenReadDataPanics_ExpectErrorCallbackNotified(t *testing
 	opts := ListenerOptions{
 		ReadTimeout: sampleReadTimeout,
 		Callbacks: Callbacks{
-			ReadDataCallbacks: []OnReadData{
-				func(id uuid.UUID, data []byte) {
-					panic(errSample)
-				},
+			ReadDataCallback: func(id uuid.UUID, data []byte) int {
+				panic(errSample)
 			},
-			ReadErrorCallbacks: []OnReadError{
-				func(id uuid.UUID, err error) {
-					called++
-					actualErr = err
-				},
+			ReadErrorCallback: func(id uuid.UUID, err error) {
+				called++
+				actualErr = err
 			},
 		},
 	}
@@ -214,22 +203,18 @@ func TestUnit_Listener_WhenReadDataPanics_ExpectErrorCallbackNotified(t *testing
 	assert.Equal(t, errSample, actualErr)
 }
 
-func TestUnit_Listener_WhenReadDataErrors_ExpectCallbackReceivesCorrectId(t *testing.T) {
+func TestUnit_Listener_WhenReadDataPanics_ExpectCallbackReceivesCorrectId(t *testing.T) {
 	client, server := newTestConnection(t, 1211)
 
 	var actualId uuid.UUID
 	opts := ListenerOptions{
 		ReadTimeout: sampleReadTimeout,
 		Callbacks: Callbacks{
-			ReadDataCallbacks: []OnReadData{
-				func(id uuid.UUID, data []byte) {
-					panic(errSample)
-				},
+			ReadDataCallback: func(id uuid.UUID, data []byte) int {
+				panic(errSample)
 			},
-			ReadErrorCallbacks: []OnReadError{
-				func(id uuid.UUID, err error) {
-					actualId = id
-				},
+			ReadErrorCallback: func(id uuid.UUID, err error) {
+				actualId = id
 			},
 		},
 	}
@@ -252,11 +237,10 @@ func TestUnit_Listener_WhenFirstReadTimeouts_ExpectDataCanStillBeRead(t *testing
 	opts := ListenerOptions{
 		ReadTimeout: 100 * time.Millisecond,
 		Callbacks: Callbacks{
-			ReadDataCallbacks: []OnReadData{
-				func(id uuid.UUID, data []byte) {
-					called++
-					actualData = data
-				},
+			ReadDataCallback: func(id uuid.UUID, data []byte) int {
+				called++
+				actualData = data
+				return 0
 			},
 		},
 	}

--- a/pkg/connection/reader.go
+++ b/pkg/connection/reader.go
@@ -5,21 +5,28 @@ import (
 	"github.com/google/uuid"
 )
 
-func readFromConnection(id uuid.UUID, conn connection, callbacks Callbacks) (timeout bool, err error) {
+func readFromConnection(id uuid.UUID, conn connection, callbacks Callbacks) (processed int, timeout bool, err error) {
 	var data []byte
+
+	processed = 0
+	timeout = false
 
 	data, err = conn.Read()
 
-	if err == nil {
-		// TODO: Change this to notify the connection that data has been processed
-		callbacks.OnReadData(id, data)
-	} else if bterr.IsErrorWithCode(err, ErrClientDisconnected) {
+	if bterr.IsErrorWithCode(err, ErrClientDisconnected) {
 		callbacks.OnDisconnect(id)
 	} else if bterr.IsErrorWithCode(err, ErrReadTimeout) {
 		timeout = true
 		err = nil
-	} else {
+	} else if err != nil {
 		callbacks.OnReadError(id, err)
+	}
+
+	// This block needs to be after the error has potentially been reset
+	// in case of a timeout. We might still have data to read despite the
+	// timeout and we want to process it.
+	if err == nil && len(data) > 0 {
+		processed = callbacks.OnReadData(id, data)
 	}
 
 	return

--- a/pkg/connection/reader.go
+++ b/pkg/connection/reader.go
@@ -11,6 +11,7 @@ func readFromConnection(id uuid.UUID, conn connection, callbacks Callbacks) (tim
 	data, err = conn.Read()
 
 	if err == nil {
+		// TODO: Change this to notify the connection that data has been processed
 		callbacks.OnReadData(id, data)
 	} else if bterr.IsErrorWithCode(err, ErrClientDisconnected) {
 		callbacks.OnDisconnect(id)

--- a/pkg/connection/reader_test.go
+++ b/pkg/connection/reader_test.go
@@ -53,11 +53,10 @@ func TestUnit_ReadFromConnection_ReadWithCallback(t *testing.T) {
 	var actualId uuid.UUID
 	var actualData []byte
 	callbacks := Callbacks{
-		ReadDataCallbacks: []OnReadData{
-			func(id uuid.UUID, data []byte) {
-				actualId = id
-				actualData = data
-			},
+		ReadDataCallback: func(id uuid.UUID, data []byte) int {
+			actualId = id
+			actualData = data
+			return 0
 		},
 	}
 	timeout, err := readFromConnection(sampleUuid, conn, callbacks)
@@ -76,10 +75,8 @@ func TestUnit_ReadFromConnection_DisconnectWithCallback(t *testing.T) {
 
 	var actualId uuid.UUID
 	callbacks := Callbacks{
-		DisconnectCallbacks: []OnDisconnect{
-			func(id uuid.UUID) {
-				actualId = id
-			},
+		DisconnectCallback: func(id uuid.UUID) {
+			actualId = id
 		},
 	}
 	timeout, err := readFromConnection(sampleUuid, conn, callbacks)

--- a/pkg/connection/reader_test.go
+++ b/pkg/connection/reader_test.go
@@ -14,8 +14,9 @@ func TestUnit_ReadFromConnection_NoError(t *testing.T) {
 	conn := Wrap(client)
 	asyncWriteSampleDataToConnection(t, server)
 
-	timeout, err := readFromConnection(sampleUuid, conn, Callbacks{})
+	processed, timeout, err := readFromConnection(sampleUuid, conn, Callbacks{})
 
+	assert.Equal(t, 0, processed)
 	assert.False(t, timeout)
 	assert.Nil(t, err, "Actual err: %v", err)
 }
@@ -27,8 +28,9 @@ func TestUnit_ReadFromConnection_ReadTimeout(t *testing.T) {
 	}
 	conn := WithOptions(client, opts)
 
-	timeout, err := readFromConnection(sampleUuid, conn, Callbacks{})
+	processed, timeout, err := readFromConnection(sampleUuid, conn, Callbacks{})
 
+	assert.Equal(t, 0, processed)
 	assert.True(t, timeout)
 	assert.Nil(t, err, "Actual err: %v", err)
 }
@@ -39,8 +41,9 @@ func TestUnit_ReadFromConnection_Disconnect(t *testing.T) {
 	assert.Nil(t, err, "Actual err: %v", err)
 	conn := Wrap(client)
 
-	timeout, err := readFromConnection(sampleUuid, conn, Callbacks{})
+	processed, timeout, err := readFromConnection(sampleUuid, conn, Callbacks{})
 
+	assert.Equal(t, 0, processed)
 	assert.False(t, timeout)
 	assert.True(t, errors.IsErrorWithCode(err, ErrClientDisconnected), "Actual err: %v", err)
 }
@@ -56,11 +59,12 @@ func TestUnit_ReadFromConnection_ReadWithCallback(t *testing.T) {
 		ReadDataCallback: func(id uuid.UUID, data []byte) int {
 			actualId = id
 			actualData = data
-			return 0
+			return 15
 		},
 	}
-	timeout, err := readFromConnection(sampleUuid, conn, callbacks)
+	processed, timeout, err := readFromConnection(sampleUuid, conn, callbacks)
 
+	assert.Equal(t, 15, processed)
 	assert.False(t, timeout)
 	assert.Nil(t, err, "Actual err: %v", err)
 	assert.Equal(t, sampleUuid, actualId)
@@ -79,8 +83,9 @@ func TestUnit_ReadFromConnection_DisconnectWithCallback(t *testing.T) {
 			actualId = id
 		},
 	}
-	timeout, err := readFromConnection(sampleUuid, conn, callbacks)
+	processed, timeout, err := readFromConnection(sampleUuid, conn, callbacks)
 
+	assert.Equal(t, 0, processed)
 	assert.False(t, timeout)
 	assert.True(t, errors.IsErrorWithCode(err, ErrClientDisconnected), "Actual err: %v", err)
 	assert.Equal(t, sampleUuid, actualId)

--- a/pkg/messages/parser.go
+++ b/pkg/messages/parser.go
@@ -25,7 +25,8 @@ func (p *parserImpl) OnReadData(id uuid.UUID, data []byte) bool {
 	msg, err := Decode(data)
 	if err != nil {
 		p.log.Warnf("Unable to decode %d byte(s) received from %v: %v", len(data), id, err)
-		return false
+		// Still return true as it can be that the data is just incomplete.
+		return true
 	}
 
 	p.queue <- msg

--- a/pkg/messages/parser.go
+++ b/pkg/messages/parser.go
@@ -6,7 +6,7 @@ import (
 )
 
 type Parser interface {
-	OnReadData(id uuid.UUID, data []byte) bool
+	OnReadData(id uuid.UUID, data []byte) (int, bool)
 }
 
 type parserImpl struct {
@@ -21,14 +21,14 @@ func NewParser(queue OutgoingQueue, log logger.Logger) Parser {
 	}
 }
 
-func (p *parserImpl) OnReadData(id uuid.UUID, data []byte) bool {
-	msg, err := Decode(data)
+func (p *parserImpl) OnReadData(id uuid.UUID, data []byte) (int, bool) {
+	msg, processed, err := Decode(data)
 	if err != nil {
 		p.log.Warnf("Unable to decode %d byte(s) received from %v: %v", len(data), id, err)
 		// Still return true as it can be that the data is just incomplete.
-		return true
+		return processed, true
 	}
 
 	p.queue <- msg
-	return true
+	return processed, true
 }

--- a/pkg/messages/parser_test.go
+++ b/pkg/messages/parser_test.go
@@ -87,6 +87,26 @@ func TestUnit_Parser_WhenReadSucceeds_ExpectSomeBytesToBeProcessed(t *testing.T)
 	assert.Equal(t, len(encoded), actual)
 }
 
+func TestUnit_Parser_WhenMoreDataThanOneMessage_ExpectNotAllBytesToBeProcessed(t *testing.T) {
+	encoded := []byte{
+		// CLIENT_CONNECTED
+		0x0, 0x0, 0x0, 0x0,
+		// UUID
+		0x2d, 0xbf, 0x26, 0x22, 0x2a, 0x95, 0x4b, 0xd1, 0x9b, 0x38, 0x2f, 0x7b, 0x4c, 0xe6, 0x5f, 0xfe,
+		// Additional garbage data
+		0x45, 0x23, 0x12, 0x78,
+	}
+
+	queue := make(OutgoingQueue, 1)
+	parser := NewParser(queue, logger.New(os.Stdout))
+
+	actual, _ := parser.OnReadData(uuid.New(), encoded)
+
+	// 4 additional bytes of garbage
+	expectedProcessed := len(encoded) - 4
+	assert.Equal(t, expectedProcessed, actual)
+}
+
 func TestUnit_Parser_WhenReadSucceeds_ExpectMessageCorrectlyDecoded(t *testing.T) {
 	encoded := []byte{
 		// CLIENT_CONNECTED

--- a/pkg/messages/parser_test.go
+++ b/pkg/messages/parser_test.go
@@ -20,14 +20,14 @@ func TestUnit_Parser_WhenReadFails_ExpectNothingPublishedToTheQueue(t *testing.T
 	parser.OnReadData(uuid.New(), []byte("not-a-message"))
 }
 
-func TestUnit_Parser_WhenReadFails_ExpectRequestToDisconnect(t *testing.T) {
+func TestUnit_Parser_WhenReadFails_ExpectRequestToStayAlive(t *testing.T) {
 	var queue OutgoingQueue
 	parser := NewParser(queue, logger.New(os.Stdout))
 
 	// Should hang in case the queue is used as the queue is unbuffered.
 	actual := parser.OnReadData(uuid.New(), []byte("not-a-message"))
 
-	assert.False(t, actual)
+	assert.True(t, actual)
 }
 
 func TestUnit_Parser_WhenReadSucceeds_ExpectMessagePushedToTheQueue(t *testing.T) {

--- a/pkg/messages/parser_test.go
+++ b/pkg/messages/parser_test.go
@@ -24,10 +24,18 @@ func TestUnit_Parser_WhenReadFails_ExpectRequestToStayAlive(t *testing.T) {
 	var queue OutgoingQueue
 	parser := NewParser(queue, logger.New(os.Stdout))
 
-	// Should hang in case the queue is used as the queue is unbuffered.
-	actual := parser.OnReadData(uuid.New(), []byte("not-a-message"))
+	_, actual := parser.OnReadData(uuid.New(), []byte("not-a-message"))
 
 	assert.True(t, actual)
+}
+
+func TestUnit_Parser_WhenReadFails_ExpectNoBytesProcessed(t *testing.T) {
+	var queue OutgoingQueue
+	parser := NewParser(queue, logger.New(os.Stdout))
+
+	actual, _ := parser.OnReadData(uuid.New(), []byte("not-a-message"))
+
+	assert.Equal(t, 0, actual)
 }
 
 func TestUnit_Parser_WhenReadSucceeds_ExpectMessagePushedToTheQueue(t *testing.T) {
@@ -58,9 +66,25 @@ func TestUnit_Parser_WhenReadSucceeds_ExpectConnectionToStayOpen(t *testing.T) {
 	queue := make(OutgoingQueue, 1)
 	parser := NewParser(queue, logger.New(os.Stdout))
 
-	actual := parser.OnReadData(uuid.New(), encoded)
+	_, actual := parser.OnReadData(uuid.New(), encoded)
 
 	assert.True(t, actual)
+}
+
+func TestUnit_Parser_WhenReadSucceeds_ExpectSomeBytesToBeProcessed(t *testing.T) {
+	encoded := []byte{
+		// CLIENT_CONNECTED
+		0x0, 0x0, 0x0, 0x0,
+		// UUID
+		0x2d, 0xbf, 0x26, 0x22, 0x2a, 0x95, 0x4b, 0xd1, 0x9b, 0x38, 0x2f, 0x7b, 0x4c, 0xe6, 0x5f, 0xfe,
+	}
+
+	queue := make(OutgoingQueue, 1)
+	parser := NewParser(queue, logger.New(os.Stdout))
+
+	actual, _ := parser.OnReadData(uuid.New(), encoded)
+
+	assert.Equal(t, len(encoded), actual)
 }
 
 func TestUnit_Parser_WhenReadSucceeds_ExpectMessageCorrectlyDecoded(t *testing.T) {
@@ -74,8 +98,9 @@ func TestUnit_Parser_WhenReadSucceeds_ExpectMessageCorrectlyDecoded(t *testing.T
 	queue := make(chan Message, 1)
 	parser := NewParser(queue, logger.New(os.Stdout))
 
-	actual := parser.OnReadData(uuid.New(), encoded)
-	assert.True(t, actual)
+	processed, keepAlive := parser.OnReadData(uuid.New(), encoded)
+	assert.Equal(t, len(encoded), processed)
+	assert.True(t, keepAlive)
 
 	msg := <-queue
 
@@ -104,8 +129,10 @@ func TestUnit_Parser_WhenQueueIsFull_ExpectReadBlocks(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		defer done.Store(true)
-		actual := parser.OnReadData(uuid.New(), encoded)
-		assert.True(t, actual)
+
+		processed, keepAlive := parser.OnReadData(uuid.New(), encoded)
+		assert.Equal(t, len(encoded), processed)
+		assert.True(t, keepAlive)
 	}()
 
 	time.Sleep(300 * time.Millisecond)

--- a/pkg/service/chat_service_test.go
+++ b/pkg/service/chat_service_test.go
@@ -31,8 +31,9 @@ func TestUnit_ChatService_OnConnect_SendsMessagesToOthers(t *testing.T) {
 	assert.True(t, accepted)
 
 	data := readFromConnection(t, client1)
-	msg, err := messages.Decode(data)
+	msg, decoded, err := messages.Decode(data)
 	assert.Nil(t, err, "Actual err: %v", err)
+	assert.Equal(t, len(data), decoded)
 	actual, ok := msg.(messages.ClientConnectedMessage)
 	assert.True(t, ok)
 	assert.Equal(t, client2Id, actual.Client)
@@ -85,8 +86,9 @@ func TestUnit_ChatService_OnDisconnect_SendsMessagesToOthers(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 
 	data := readFromConnection(t, client2)
-	msg, err := messages.Decode(data)
+	msg, decoded, err := messages.Decode(data)
 	assert.Nil(t, err, "Actual err: %v", err)
+	assert.Equal(t, len(data), decoded)
 	actual, ok := msg.(messages.ClientDisconnectedMessage)
 	assert.True(t, ok)
 	assert.Equal(t, client1Id, actual.Client)
@@ -129,8 +131,9 @@ func TestUnit_ChatService_OnDirectMessage_RoutesMessageToCorrectClient(t *testin
 	time.Sleep(100 * time.Millisecond)
 
 	data := readFromConnection(t, client2)
-	actual, err := messages.Decode(data)
+	actual, decoded, err := messages.Decode(data)
 	assert.Nil(t, err, "Actual err: %v", err)
+	assert.Equal(t, len(data), decoded)
 	assert.Equal(t, msg, actual)
 
 	assertNoDataReceived(t, client3)

--- a/pkg/tcp/connection_manager_test.go
+++ b/pkg/tcp/connection_manager_test.go
@@ -84,10 +84,10 @@ func TestUnit_ConnectionManager_WhenClientSendsData_ExpectCallbackNotified(t *te
 	var called int
 	var wg sync.WaitGroup
 	wg.Add(1)
-	config.Callbacks.ReadDataCallback = func(id uuid.UUID, data []byte) bool {
+	config.Callbacks.ReadDataCallback = func(id uuid.UUID, data []byte) (int, bool) {
 		defer wg.Done()
 		called++
-		return true
+		return 0, true
 	}
 
 	cm := newConnectionManager(config, logger.New(os.Stdout))
@@ -129,9 +129,9 @@ func TestUnit_ConnectionManager_WhenClientConnectsAndIsDenied_ExpectConnectionTo
 func TestUnit_ConnectionManager_WhenReadDataCallbackIndicatesToCloseTheConnection_ExpectConnectionToBeClosed(t *testing.T) {
 	config := newTestManagerConfig()
 	var called atomic.Int32
-	config.Callbacks.ReadDataCallback = func(id uuid.UUID, data []byte) bool {
+	config.Callbacks.ReadDataCallback = func(id uuid.UUID, data []byte) (int, bool) {
 		called.Add(1)
-		return false
+		return 0, false
 	}
 
 	cm := newConnectionManager(config, logger.New(os.Stdout))
@@ -154,8 +154,8 @@ func TestUnit_ConnectionManager_WhenReadDataCallbackIndicatesToCloseTheConnectio
 
 func TestUnit_ConnectionManager_WhenReadDataCallbackIndicatesToCloseTheConnection_ExpectDisconnectCallbackIsCalled(t *testing.T) {
 	config := newTestManagerConfig()
-	config.Callbacks.ReadDataCallback = func(id uuid.UUID, data []byte) bool {
-		return false
+	config.Callbacks.ReadDataCallback = func(id uuid.UUID, data []byte) (int, bool) {
+		return 0, false
 	}
 	var called atomic.Int32
 	config.Callbacks.DisconnectCallback = func(id uuid.UUID) {
@@ -206,7 +206,7 @@ func TestUnit_ConnectionManager_WhenDataReadCallbackPanics_ExpectConnectionToBeC
 	var called int
 	var wg sync.WaitGroup
 	wg.Add(1)
-	config.Callbacks.ReadDataCallback = func(id uuid.UUID, data []byte) bool {
+	config.Callbacks.ReadDataCallback = func(id uuid.UUID, data []byte) (int, bool) {
 		defer wg.Done()
 		called++
 		panic(errSample)

--- a/pkg/tcp/connection_manager_test.go
+++ b/pkg/tcp/connection_manager_test.go
@@ -3,8 +3,6 @@ package tcp
 import (
 	"net"
 	"os"
-	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -65,9 +63,11 @@ func TestUnit_ConnectionManager_WhenCloseIsCalled_ExpectOnDisconnectToBeCalledOn
 
 func TestUnit_ConnectionManager_WhenClientConnects_ExpectCallbackNotified(t *testing.T) {
 	config := newTestManagerConfig()
-	var called int
+	called := make(chan struct{}, 1)
 	config.Callbacks.ConnectCallback = func(id uuid.UUID, conn net.Conn) bool {
-		called++
+		defer func() {
+			called <- struct{}{}
+		}()
 		return true
 	}
 	cm := newConnectionManager(config, logger.New(os.Stdout))
@@ -76,17 +76,16 @@ func TestUnit_ConnectionManager_WhenClientConnects_ExpectCallbackNotified(t *tes
 
 	cm.OnClientConnected(server)
 
-	assert.Equal(t, 1, called)
+	<-called
 }
 
 func TestUnit_ConnectionManager_WhenClientSendsData_ExpectCallbackNotified(t *testing.T) {
 	config := newTestManagerConfig()
-	var called int
-	var wg sync.WaitGroup
-	wg.Add(1)
+	called := make(chan struct{}, 1)
 	config.Callbacks.ReadDataCallback = func(id uuid.UUID, data []byte) (int, bool) {
-		defer wg.Done()
-		called++
+		defer func() {
+			called <- struct{}{}
+		}()
 		return 0, true
 	}
 
@@ -100,16 +99,16 @@ func TestUnit_ConnectionManager_WhenClientSendsData_ExpectCallbackNotified(t *te
 	assert.Equal(t, n, len(sampleData))
 	assert.Nil(t, err, "Actual err: %v", err)
 
-	wg.Wait()
-
-	assert.Equal(t, 1, called)
+	<-called
 }
 
 func TestUnit_ConnectionManager_WhenClientConnectsAndIsDenied_ExpectConnectionToBeClosed(t *testing.T) {
 	config := newTestManagerConfig()
-	var called int
+	called := make(chan struct{}, 1)
 	config.Callbacks.ConnectCallback = func(id uuid.UUID, conn net.Conn) bool {
-		called++
+		defer func() {
+			called <- struct{}{}
+		}()
 		return false
 	}
 
@@ -119,18 +118,18 @@ func TestUnit_ConnectionManager_WhenClientConnectsAndIsDenied_ExpectConnectionTo
 
 	cm.OnClientConnected(server)
 
-	// Wait for connection to be processed.
-	time.Sleep(50 * time.Millisecond)
+	<-called
 
-	assert.Equal(t, 1, called)
 	assertConnectionIsClosed(t, client)
 }
 
 func TestUnit_ConnectionManager_WhenReadDataCallbackIndicatesToCloseTheConnection_ExpectConnectionToBeClosed(t *testing.T) {
 	config := newTestManagerConfig()
-	var called atomic.Int32
+	called := make(chan struct{}, 1)
 	config.Callbacks.ReadDataCallback = func(id uuid.UUID, data []byte) (int, bool) {
-		called.Add(1)
+		defer func() {
+			called <- struct{}{}
+		}()
 		return len(data), false
 	}
 
@@ -144,11 +143,11 @@ func TestUnit_ConnectionManager_WhenReadDataCallbackIndicatesToCloseTheConnectio
 	assert.Equal(t, n, len(sampleData))
 	assert.Nil(t, err, "Actual err: %v", err)
 
+	<-called
 	// Wait long enough for the read timeout to expire and connection
 	// to be effectively closed.
 	time.Sleep(200 * time.Millisecond)
 
-	assert.Equal(t, int32(1), called.Load())
 	assertConnectionIsClosed(t, client)
 }
 
@@ -157,9 +156,9 @@ func TestUnit_ConnectionManager_WhenReadDataCallbackIndicatesToCloseTheConnectio
 	config.Callbacks.ReadDataCallback = func(id uuid.UUID, data []byte) (int, bool) {
 		return len(data), false
 	}
-	var called atomic.Int32
+	called := make(chan struct{}, 1)
 	config.Callbacks.DisconnectCallback = func(id uuid.UUID) {
-		called.Add(1)
+		called <- struct{}{}
 	}
 
 	cm := newConnectionManager(config, logger.New(os.Stdout))
@@ -172,21 +171,14 @@ func TestUnit_ConnectionManager_WhenReadDataCallbackIndicatesToCloseTheConnectio
 	assert.Equal(t, n, len(sampleData))
 	assert.Nil(t, err, "Actual err: %v", err)
 
-	// Wait long enough for the read timeout to expire and connection
-	// to be effectively closed.
-	time.Sleep(200 * time.Millisecond)
-
-	assert.Equal(t, int32(1), called.Load())
+	<-called
 }
 
 func TestUnit_ConnectionManager_WhenClientDisconnects_ExpectCallbackNotified(t *testing.T) {
 	config := newTestManagerConfig()
-	var called int
-	var wg sync.WaitGroup
-	wg.Add(1)
+	called := make(chan struct{}, 1)
 	config.Callbacks.DisconnectCallback = func(id uuid.UUID) {
-		defer wg.Done()
-		called++
+		called <- struct{}{}
 	}
 
 	cm := newConnectionManager(config, logger.New(os.Stdout))
@@ -196,19 +188,16 @@ func TestUnit_ConnectionManager_WhenClientDisconnects_ExpectCallbackNotified(t *
 	cm.OnClientConnected(server)
 	client.Close()
 
-	wg.Wait()
-
-	assert.Equal(t, 1, called)
+	<-called
 }
 
 func TestUnit_ConnectionManager_WhenDataReadCallbackPanics_ExpectConnectionToBeClosed(t *testing.T) {
 	config := newTestManagerConfig()
-	var called int
-	var wg sync.WaitGroup
-	wg.Add(1)
+	called := make(chan struct{}, 1)
 	config.Callbacks.ReadDataCallback = func(id uuid.UUID, data []byte) (int, bool) {
-		defer wg.Done()
-		called++
+		defer func() {
+			called <- struct{}{}
+		}()
 		panic(errSample)
 	}
 
@@ -222,14 +211,11 @@ func TestUnit_ConnectionManager_WhenDataReadCallbackPanics_ExpectConnectionToBeC
 	assert.Equal(t, n, len(sampleData))
 	assert.Nil(t, err, "Actual err: %v", err)
 
-	wg.Wait()
+	<-called
 	// Wait long enough for the read timeout to expire and connection
 	// to be effectively closed.
 	time.Sleep(200 * time.Millisecond)
 
-	// The callback can be called multiple times because we don't report any
-	// data processed as it's panicking.
-	assert.GreaterOrEqual(t, called, 1)
 	assertConnectionIsClosed(t, client)
 }
 


### PR DESCRIPTION
# Work

## The initial situation

The logic to accept messages from clients is to listen to the connection until either:
* we reach a predefined timeout
* we receive a new line (`\n`) character

In both cases we then return the result of the reading for the server to interpret. We chose to implement a 0 tolerance policy meaning that any read that is not a valid message will be discarded and the corresponding connection terminated.

## Recent improvements

This approach is not optimal for at least two reasons:
1. as we don't **control when the timeout is reached**, we have no way to guarantee that the read operation on the connection will yield a well formed message.
2. as we encode messages in binary, we can't guarantee that there will be no new line character within the message (not even mentioning supporting new line characters in messages).

Point 1. was addressed in [d707be6](https://github.com/Knoblauchpilze/chat-server/commit/d707be6ff3ac3ca6885ecc1ac2c1bce027797bf7) where we keep an internal buffer in the connection. This buffer accumulates the data received until a new line appears or a threshold is reached.

## What does this PR bring?

This PR aims at addressing point 2. above. Is it a bit more complex to solve. The situation is as follows:

![connection-logic drawio](https://github.com/user-attachments/assets/5b4e854b-d0e6-4bbe-9c14-fe4167c6e813)

With the current architecture if we choose to not wait for a new line to appear, what will most likely happen is that:
* the listener will read from the connection and (1.) and the connection will report some data (3.).
* this data is most likely incomplete and so the decoding (5.) will fail.
* this will trigger the `ConnectionManager` to close the connection (7.) without a chance to wait for the rest of the data.

To change this, we need to make the chain a bit more flexible and not fail when the parser fails to disconnect the data. This is not a big issue because since [d707be6](https://github.com/Knoblauchpilze/chat-server/commit/d707be6ff3ac3ca6885ecc1ac2c1bce027797bf7) (see previous section) the connection anyway keeps an internal buffer and will terminate the connection if too much data is received without the server being able to make sense of it.

In order to achieve this, we modified the `OnReadData` callback from this:
```go
// The return value should indicate whether or not the connection should stay open.
type OnReadData func(id uuid.UUID, data []byte) bool
```
To this:
```go
// The return value should indicate whether or not the connection should stay open
// and how many bytes were processed.
type OnReadData func(id uuid.UUID, data []byte) (int, bool)
```
([source](https://github.com/Knoblauchpilze/chat-server/pull/1/files#diff-ea72500c310bb220cf56eff10c67a3c12a6cfd0ee5955c3ae7e6b3d88e607d5eL15-R17))

By allowing the callback to communicate how many bytes were processed we allow the connection to:
* keep all the data in memory until it is processed.
* precisely process only a message even when the data for the next message is already received.
* account for the read timeout in case we receive incomplete data.

Additionally, the message parser is not terminating the connection anymore when it can't [decode the data](https://github.com/Knoblauchpilze/chat-server/pull/1/files#diff-522c2d04579ea1cafa4978d401a7d2aa50e6158ca38f405ec9e6950b79026ff1L28-R29): this makes sure that the `ConnectionManager` will not terminate the connection: instead, we rely on the connection to monitor how much data it has pending and take appropriate action when needed. This will materialize in the form of the connection returning a `ErrTooLargeIncompleteData` error code upon reading data. Such an error is handled as any other error (as a read failure) and will trigger the termination of the connection.

# Tests

Some existing tests were refactored to accommodate for the new behavior. New tests were created to verify the new logic. Specifically:
* in the `Decoder` to verify that we report correctly the number of bytes processed.
* in the callbacks to verify that the propagation works properly.
* in the `Connection` to make sure that we do not wait on receiving a new line character to report the data.
* in the `Parser` to verify that we report correctly the number of bytes processed.
* in the controller to verify that when we receive a message in multiple pieces we still allow the callbacks to process it properly.
* in the main server to verify that we disconnect clients when they send too much data that we can't make sense of.

# Future work

The goal of having the limit of data in the `Connection` is to prevent malicious actors to send garbage data which we can't decode and progressively use up all the memory in the server. A downside of that is that it also limits how big the (legitimate) messages can be.

In the future we could improve this in multiple ways:
* make this threshold configurable (currently it's hard-coded).
* create additional message types to potentially split bigger contents in multiple chunks (e.g. `PARTIAL_MESSAGE`).

Currently it does not look like a big limitations to not be able to send longer messages. For a prototype it's more than enough to allow messages of a couple of thousand characters.
