### PR TITLE
feat: OnConnect generates an identifier for a connection

### DIFF
--- a/internal/service/chat_service_test.go
+++ b/internal/service/chat_service_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Knoblauchpilze/backend-toolkit/pkg/logger"
 	"github.com/Knoblauchpilze/chat-server/pkg/clients"
 	"github.com/Knoblauchpilze/chat-server/pkg/messages"
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -29,14 +28,12 @@ func TestUnit_ChatService_OnConnect_SendsMessagesToOthers(t *testing.T) {
 	_, server2 := newTestConnection(t, 6000)
 	wg := asyncRunChatService(t, service)
 
-	client1Id := uuid.New()
-	accepted := callbacks.OnConnect(client1Id, server1)
+	accepted, _ := callbacks.OnConnect(server1)
 	assert.True(t, accepted)
 
 	time.Sleep(reasonableWaitTimeForOnConnectMessageToBeProcessed)
 
-	client2Id := uuid.New()
-	accepted = callbacks.OnConnect(client2Id, server2)
+	accepted, client2Id := callbacks.OnConnect(server2)
 	assert.True(t, accepted)
 
 	data := readFromConnection(t, client1)
@@ -57,14 +54,12 @@ func TestUnit_ChatService_OnConnect_DoesNotSendMessageToSelf(t *testing.T) {
 	client2, server2 := newTestConnection(t, 6001)
 	wg := asyncRunChatService(t, service)
 
-	client1Id := uuid.New()
-	accepted := callbacks.OnConnect(client1Id, server1)
+	accepted, _ := callbacks.OnConnect(server1)
 	assert.True(t, accepted)
 
 	time.Sleep(reasonableWaitTimeForOnConnectMessageToBeProcessed)
 
-	client2Id := uuid.New()
-	accepted = callbacks.OnConnect(client2Id, server2)
+	accepted, _ = callbacks.OnConnect(server2)
 	assert.True(t, accepted)
 
 	assertNoDataReceived(t, client2)
@@ -79,14 +74,12 @@ func TestUnit_ChatService_OnDisconnect_SendsMessagesToOthers(t *testing.T) {
 	client2, server2 := newTestConnection(t, 6001)
 	wg := asyncRunChatService(t, service)
 
-	client1Id := uuid.New()
-	accepted := callbacks.OnConnect(client1Id, server1)
+	accepted, client1Id := callbacks.OnConnect(server1)
 	assert.True(t, accepted)
 
 	time.Sleep(reasonableWaitTimeForOnConnectMessageToBeProcessed)
 
-	client2Id := uuid.New()
-	accepted = callbacks.OnConnect(client2Id, server2)
+	accepted, _ = callbacks.OnConnect(server2)
 	assert.True(t, accepted)
 
 	callbacks.OnDisconnect(client1Id)
@@ -113,16 +106,13 @@ func TestUnit_ChatService_OnDirectMessage_RoutesMessageToCorrectClient(t *testin
 	client3, server3 := newTestConnection(t, 6002)
 	wg := asyncRunChatService(t, service)
 
-	client1Id := uuid.New()
-	accepted := callbacks.OnConnect(client1Id, server1)
+	accepted, client1Id := callbacks.OnConnect(server1)
 	assert.True(t, accepted)
 
-	client2Id := uuid.New()
-	accepted = callbacks.OnConnect(client2Id, server2)
+	accepted, client2Id := callbacks.OnConnect(server2)
 	assert.True(t, accepted)
 
-	client3Id := uuid.New()
-	accepted = callbacks.OnConnect(client3Id, server3)
+	accepted, _ = callbacks.OnConnect(server3)
 	assert.True(t, accepted)
 
 	time.Sleep(reasonableWaitTimeForOnConnectMessageToBeProcessed)

--- a/pkg/clients/callbacks.go
+++ b/pkg/clients/callbacks.go
@@ -6,8 +6,9 @@ import (
 	"github.com/google/uuid"
 )
 
-// The return value should indicate whether or not the connection is accepted.
-type OnConnect func(id uuid.UUID, conn net.Conn) bool
+// The return value should indicate whether or not the connection is accepted
+// and an identifier to refer to it.
+type OnConnect func(conn net.Conn) (bool, uuid.UUID)
 
 // The connection will automatically be closed after this callback is triggered.
 type OnDisconnect func(id uuid.UUID)
@@ -26,11 +27,11 @@ type Callbacks struct {
 	ReadDataCallback   OnReadData
 }
 
-func (c Callbacks) OnConnect(id uuid.UUID, conn net.Conn) bool {
+func (c Callbacks) OnConnect(conn net.Conn) (bool, uuid.UUID) {
 	if c.ConnectCallback == nil {
-		return true
+		return false, uuid.Nil
 	}
-	return c.ConnectCallback(id, conn)
+	return c.ConnectCallback(conn)
 }
 
 func (c Callbacks) OnDisconnect(id uuid.UUID) {

--- a/pkg/connection/listener.go
+++ b/pkg/connection/listener.go
@@ -11,6 +11,7 @@ import (
 )
 
 type ListenerOptions struct {
+	Id          uuid.UUID
 	ReadTimeout time.Duration
 	Callbacks   Callbacks
 }
@@ -35,7 +36,7 @@ func New(conn net.Conn, opts ListenerOptions) Listener {
 	connOpts := WithReadTimeout(opts.ReadTimeout)
 
 	l := &listenerImpl{
-		id:        uuid.New(),
+		id:        opts.Id,
 		conn:      WithOptions(conn, connOpts),
 		callbacks: opts.Callbacks,
 	}

--- a/pkg/connection/listener_test.go
+++ b/pkg/connection/listener_test.go
@@ -14,6 +14,17 @@ var sampleListenerOptions = ListenerOptions{
 	ReadTimeout: sampleReadTimeout,
 }
 
+func TestUnit_Listener_UsesProvidedId(t *testing.T) {
+	_, server := newTestConnection(t, 1214)
+	opts := ListenerOptions{
+		Id: sampleUuid,
+	}
+
+	listener := New(server, opts)
+
+	assert.Equal(t, sampleUuid, listener.Id())
+}
+
 func TestUnit_Listener_StartStop(t *testing.T) {
 	_, server := newTestConnection(t, 1200)
 	listener := New(server, sampleListenerOptions)


### PR DESCRIPTION
# Work

Currently the way we handle incoming connection in the server is as follows:
* a client opens a connection to the server
* the `ConnectionManager` generates an identifier for it
* it calls the `OnConnect` callback on the `ClientManager` with the generated identifier
* this callback always accepts the connection and generates a `CLIENT_CONNECTED` message with the provided identifier

This is not optimal. As we want to link connection to existing chat users, we should have a way to determine which client is a connection associated to. We want to handle this with the concept of a handshake: upon connecting to the server the client has to respect a certain protocol and send some information about who they are. Failure to do so will lead the server to terminate the connection.

With the current approach we can't easily do that: as the identifier is generated even before the `OnConnect` callback is called (where the handshake protocol will most likely reside), this would mean we need to override the identifier or somehow attach the generated identifier with the client's identifier. this is quite cumbersome.

In this PR, we change the way the `OnConnect` callback looks like from this:
```go
type OnConnect func(id uuid.UUID, conn net.Conn) bool
```

To this:
```go
type OnConnect func(conn net.Conn) (bool, uuid.UUID)
```

It allows in the future to refine the `OnConnect` callback in the `ClientManager` to generate an identifier as we see fit, one of them being to get it from the connection directly during the handshake process.

This PR still **generates a random identifier** as we did not implement the handshake yet. It will be changed in the future. As we don't want to generate an identifier for nothing, we also changed the default behavior of the `OnConnect` to always return `false` (see [here](https://github.com/Knoblauchpilze/chat-server/pull/3/files#diff-ea72500c310bb220cf56eff10c67a3c12a6cfd0ee5955c3ae7e6b3d88e607d5eR32)). This seems more robust as the server does not want to accept connections by default unless they prove that they are legitimate.

# Tests

All existing tests are still passing and we added relevant tests to verify that:
* the `OnConnect` callback denies connections by default
* the `Listener` uses the provided identifier

Additionally:
* the tests which needed to specify the `OnConnect` callback were adapted to correctly match the new interface.
* tests which assumed that no `OnConnect` callback would always accept the connection were adapted to provide a default callback.

Running the server locally yields to the same behavior as before in terms of sending messages to other clients and disconnections.

# Future work

This work is the first step to allow the implementation of a proper handshake mechanism. Such a mechanism would help verifying that clients are legitimate and also allow to associate a connection with an existing chat user.

