### PR TITLE
feat: Handshake when a client opens a new connection

### DIFF
--- a/pkg/clients/errors.go
+++ b/pkg/clients/errors.go
@@ -7,3 +7,21 @@ const (
 	IncompleteHandshake errors.ErrorCode = 501
 	HandshakeFailure    errors.ErrorCode = 502
 )
+
+func newHandshakeTimeoutError() error {
+	return errors.NewCodeWithDetails(HandshakeTimeout, "timeout")
+}
+
+func newHandshakeIncompleteError() error {
+	return errors.NewCodeWithDetails(
+		IncompleteHandshake,
+		"not enough data to received to perform handshake",
+	)
+}
+
+func wrapHandshakeFailureError(err error) error {
+	return errors.NewCodeWithDetails(
+		HandshakeFailure,
+		"failed to interpret handshake data",
+	)
+}

--- a/pkg/clients/handshake.go
+++ b/pkg/clients/handshake.go
@@ -19,11 +19,11 @@ func Handshake(conn net.Conn, timeout time.Duration) (uuid.UUID, error) {
 
 	n, err := conn.Read(data)
 	if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
-		return uuid.Nil, errors.NewCode(HandshakeTimeout)
+		return uuid.Nil, newHandshakeTimeoutError()
 	} else if err != nil {
-		return uuid.Nil, errors.WrapCode(err, HandshakeFailure)
+		return uuid.Nil, wrapHandshakeFailureError(err)
 	} else if n != len(id) {
-		return uuid.Nil, errors.NewCode(IncompleteHandshake)
+		return uuid.Nil, newHandshakeIncompleteError()
 	}
 
 	id, err = uuid.FromBytes(data)


### PR DESCRIPTION
# Work

Whenever a client connects, there are two things we need to do first:
* make sure that this is a legitimate client
* find out which user this connection is associated to

Those two things should be managed by the handshake: this is a process which we want to install in the `ClientManager` and which should take place on the `OnConnect` event.

We already worked a bit in this direction:
* #

# Tests

# Future work
