### PR TITLE
feat: ClientManager uses the handshake and adapted tests

### DIFF
--- a/cmd/chat-server/internal/helper_test.go
+++ b/cmd/chat-server/internal/helper_test.go
@@ -61,9 +61,9 @@ func assertConnectionIsStillOpen(t *testing.T, conn net.Conn) {
 	_, err := conn.Read(oneByte)
 
 	opErr, ok := err.(*net.OpError)
-	assert.True(t, ok)
+	assert.True(t, ok, "Actual err: %v", err)
 	if ok {
-		assert.True(t, opErr.Timeout())
+		assert.True(t, opErr.Timeout(), "Actual err: %v", opErr)
 	}
 }
 

--- a/cmd/chat-server/internal/helper_test.go
+++ b/cmd/chat-server/internal/helper_test.go
@@ -240,3 +240,16 @@ func assertResponseAndExtractDetails[T any](
 
 	return out
 }
+
+func connectToServerAndSendHandshake(t *testing.T, port uint16) (net.Conn, uuid.UUID) {
+	clientId := uuid.New()
+
+	conn, err := net.Dial("tcp", fmt.Sprintf(":%d", port))
+	assert.Nil(t, err, "Actual err: %v", err)
+
+	n, err := conn.Write(clientId[:])
+	assert.Nil(t, err, "Actual err: %v", err)
+	assert.Equal(t, len(clientId), n)
+
+	return conn, clientId
+}

--- a/cmd/chat-server/internal/tcp_listen_and_serve_test.go
+++ b/cmd/chat-server/internal/tcp_listen_and_serve_test.go
@@ -230,9 +230,9 @@ func TestUnit_TcpListenAndServe_WhenMessageIsSentInMultiplePieces_ExpectItToCorr
 	conn, err := net.Dial("tcp", ":7008")
 	assert.Nil(t, err, "Actual err: %v", err)
 
-	clientId1 := uuid.New()
-	clientId2 := uuid.New()
-	msg := messages.NewDirectMessage(clientId1, clientId2, "hello")
+	client1Id := uuid.New()
+	client2Id := uuid.New()
+	msg := messages.NewDirectMessage(client1Id, client2Id, "hello")
 	data, err := messages.Encode(msg)
 	assert.Nil(t, err, "Actual err: %v", err)
 
@@ -263,8 +263,8 @@ func TestUnit_TcpListenAndServe_WhenMessageIsSentInMultiplePieces_ExpectItToCorr
 	assert.GreaterOrEqual(t, called.Load(), int32(2))
 	actual, err := messages.ToMessageStruct[messages.DirectMessage](receivedMessage)
 	assert.Nil(t, err, "Actual err: %v", err)
-	assert.Equal(t, clientId1, actual.Emitter)
-	assert.Equal(t, clientId2, actual.Receiver)
+	assert.Equal(t, client1Id, actual.Emitter)
+	assert.Equal(t, client2Id, actual.Receiver)
 	assert.Equal(t, "hello", actual.Content)
 }
 

--- a/cmd/chat-server/internal/tcp_server.go
+++ b/cmd/chat-server/internal/tcp_server.go
@@ -7,8 +7,13 @@ import (
 	"github.com/Knoblauchpilze/chat-server/internal/service"
 )
 
-func RunTcpServer(ctx context.Context, conf Configuration, log logger.Logger) error {
-	chat := service.NewChatService(conf.ConnectTimeout, log)
+func RunTcpServer(
+	ctx context.Context,
+	conf Configuration,
+	services service.Services,
+	log logger.Logger,
+) error {
+	chat := services.Chat
 	conf.Callbacks = chat.GenerateCallbacks()
 
 	chat.Start()

--- a/cmd/chat-server/internal/tcp_server_test.go
+++ b/cmd/chat-server/internal/tcp_server_test.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	"github.com/Knoblauchpilze/backend-toolkit/pkg/logger"
+	"github.com/Knoblauchpilze/chat-server/internal/service"
+	"github.com/Knoblauchpilze/chat-server/pkg/clients"
 	"github.com/Knoblauchpilze/chat-server/pkg/messages"
 	"github.com/stretchr/testify/assert"
 )
@@ -199,6 +201,15 @@ func asyncRunTcpServer(
 	var err error
 	var wg sync.WaitGroup
 
+	log := logger.New(os.Stdout)
+	services := service.Services{
+		Chat: service.NewChatService(
+			clients.Handshake,
+			config.ConnectTimeout,
+			log,
+		),
+	}
+
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
@@ -208,7 +219,7 @@ func asyncRunTcpServer(
 			}
 		}()
 
-		err = RunTcpServer(ctx, config, logger.New(os.Stdout))
+		err = RunTcpServer(ctx, config, services, log)
 		assert.Nil(t, err, "Actual err: %v", err)
 	}()
 

--- a/internal/service/chat_service.go
+++ b/internal/service/chat_service.go
@@ -22,12 +22,14 @@ type chatServiceImpl struct {
 	messageProcessingService messages.ProcessingService
 }
 
-func NewChatService(connectTimeout time.Duration, log logger.Logger) ChatService {
+func NewChatService(
+	handshakeFunc clients.HandshakeFunc, connectTimeout time.Duration, log logger.Logger,
+) ChatService {
 	queue := make(chan messages.Message, incomingMessagesBufferSize)
 	props := clients.ManagerProps{
 		Queue:          queue,
 		ConnectTimeout: connectTimeout,
-		Handshake:      clients.Handshake,
+		Handshake:      handshakeFunc,
 		Log:            log,
 	}
 	manager := clients.NewManager(props)

--- a/internal/service/chat_service_test.go
+++ b/internal/service/chat_service_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Knoblauchpilze/backend-toolkit/pkg/logger"
 	"github.com/Knoblauchpilze/chat-server/pkg/clients"
 	"github.com/Knoblauchpilze/chat-server/pkg/messages"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -143,7 +144,15 @@ func TestUnit_ChatService_OnDirectMessage_RoutesMessageToCorrectClient(t *testin
 }
 
 func newTestChatService() (ChatService, clients.Callbacks) {
-	service := NewChatService(reasonableConnectTimeout, logger.New(os.Stdout))
+	handshakeFunc := func(net.Conn, time.Duration) (uuid.UUID, error) {
+		return uuid.New(), nil
+	}
+
+	service := NewChatService(
+		handshakeFunc,
+		reasonableConnectTimeout,
+		logger.New(os.Stdout),
+	)
 	return service, service.GenerateCallbacks()
 }
 

--- a/internal/service/services.go
+++ b/internal/service/services.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/Knoblauchpilze/backend-toolkit/pkg/db"
 	"github.com/Knoblauchpilze/backend-toolkit/pkg/logger"
+	"github.com/Knoblauchpilze/chat-server/pkg/clients"
 	"github.com/Knoblauchpilze/chat-server/pkg/repositories"
 )
 
@@ -23,6 +24,10 @@ func New(
 	return Services{
 		Room: NewRoomService(conn, repos),
 		User: NewUserService(conn, repos),
-		Chat: NewChatService(connectTimeout, log),
+		Chat: NewChatService(
+			clients.Handshake,
+			connectTimeout,
+			log,
+		),
 	}
 }

--- a/pkg/clients/client_manager.go
+++ b/pkg/clients/client_manager.go
@@ -58,7 +58,7 @@ func (m *managerImpl) OnConnect(conn net.Conn) (bool, uuid.UUID) {
 		m.log.Warnf("OnConnect: panic while performing handshake: %v", err)
 		return false, uuid.Nil
 	} else if handshakeErr != nil {
-		m.log.Warnf("OnConnect: handsahke failed: %v", handshakeErr)
+		m.log.Warnf("OnConnect: handshake failed: %v", handshakeErr)
 		return false, uuid.Nil
 	}
 


### PR DESCRIPTION
# Work

## Context

Whenever a client connects, there are two things we need to do first:
* make sure that this is a legitimate client
* find out which user this connection is associated to

Those two things should be managed by the handshake: this is a process which we want to install in the `ClientManager` and which should take place on the `OnConnect` event.

We already worked a bit in this direction:
* #3 aimed at allowing the `OnConnect` to return an identifier instead of being provided one. This is helpful because the identifier should come from the client ideally (to allow knowing who is connecting).
* [69d0a28](https://github.com/Knoblauchpilze/chat-server/commit/69d0a284ee245959e408796371a1472d687cec41) implemented part of a simplistic handshake by expecting the client to provide an identifier within 1 second of connecting.
* [a4a5196](https://github.com/Knoblauchpilze/chat-server/commit/a4a5196be811ff15f42120ed52c4969aa9bd771c) makes the `ClientManager` able to accept a handshake function.

## What does this PR bring?

This PR uses the existing foundations to make the `ClientManager` use the handshake and deny/accept clients based on the result.

# Tests

Some additional unit tests were written:
* in `ClientManager` to verify that when the handshake succeeds/fails we return the correct status from the `OnConnect` callback.
* in the server to verify that when a client misbehaves by not performing a handshake, it gets terminated.

# Future work

The handshake protocol is not yet complete. Currently any client can connect and send garbage which we will interpret as an identifier. What's missing is the verification that the ID received is actually existing in the database and corresponds to a real client.

This will be addressed in a follow-up PR.
