### PR TITLE
feat: Register users in general room

### DIFF
--- a/cmd/chat-server/internal/helper_test.go
+++ b/cmd/chat-server/internal/helper_test.go
@@ -116,6 +116,9 @@ func newTestDbConnection(t *testing.T) db.Connection {
 func insertTestUser(t *testing.T, dbConn db.Connection) persistence.User {
 	repo := repositories.NewUserRepository(dbConn)
 
+	tx, err := dbConn.BeginTx(context.Background())
+	assert.Nil(t, err, "Actual err: %v", err)
+
 	id := uuid.New()
 	user := persistence.User{
 		Id:        id,
@@ -123,7 +126,8 @@ func insertTestUser(t *testing.T, dbConn db.Connection) persistence.User {
 		ApiUser:   uuid.New(),
 		CreatedAt: time.Now(),
 	}
-	out, err := repo.Create(context.Background(), user)
+	out, err := repo.Create(context.Background(), tx, user)
+	tx.Close(context.Background())
 	assert.Nil(t, err, "Actual err: %v", err)
 
 	assertUserExists(t, dbConn, id)

--- a/internal/controller/users_test.go
+++ b/internal/controller/users_test.go
@@ -338,13 +338,17 @@ func insertTestUser(t *testing.T, conn db.Connection) persistence.User {
 func insertTestUserWithName(t *testing.T, conn db.Connection, name string) persistence.User {
 	repo := repositories.NewUserRepository(conn)
 
+	tx, err := conn.BeginTx(context.Background())
+	assert.Nil(t, err, "Actual err: %v", err)
+
 	id := uuid.New()
 	user := persistence.User{
 		Id:      id,
 		Name:    name,
 		ApiUser: uuid.New(),
 	}
-	out, err := repo.Create(context.Background(), user)
+	out, err := repo.Create(context.Background(), tx, user)
+	tx.Close(context.Background())
 	assert.Nil(t, err, "Actual err: %v", err)
 
 	assertUserExists(t, conn, out.Id)

--- a/pkg/clients/handshake_test.go
+++ b/pkg/clients/handshake_test.go
@@ -109,13 +109,17 @@ func newTestHandshake(t *testing.T) (Handshake, db.Connection) {
 func insertTestUser(t *testing.T, conn db.Connection) persistence.User {
 	repo := repositories.NewUserRepository(conn)
 
+	tx, err := conn.BeginTx(context.Background())
+	assert.Nil(t, err, "Actual err: %v", err)
+
 	id := uuid.New()
 	user := persistence.User{
 		Id:      id,
 		Name:    fmt.Sprintf("my-user-%s", id),
 		ApiUser: uuid.New(),
 	}
-	out, err := repo.Create(context.Background(), user)
+	out, err := repo.Create(context.Background(), tx, user)
+	tx.Close(context.Background())
 	assert.Nil(t, err, "Actual err: %v", err)
 
 	assertUserExists(t, conn, out.Id)

--- a/pkg/repositories/errors.go
+++ b/pkg/repositories/errors.go
@@ -1,0 +1,7 @@
+package repositories
+
+import "github.com/Knoblauchpilze/backend-toolkit/pkg/errors"
+
+const (
+	ErrNoSuchRoom errors.ErrorCode = 600
+)

--- a/pkg/repositories/helper_test.go
+++ b/pkg/repositories/helper_test.go
@@ -33,3 +33,31 @@ func registerUserInRoom(
 	)
 	assert.Nil(t, err, "Actual err: %v", err)
 }
+
+func assertUserRegisteredInRoom(
+	t *testing.T, conn db.Connection, user uuid.UUID, room uuid.UUID,
+) {
+	value, err := db.QueryOne[int](
+		context.Background(),
+		conn,
+		"SELECT COUNT(*) FROM room_user WHERE chat_user = $1 AND room = $2",
+		user,
+		room,
+	)
+	assert.Nil(t, err, "Actual err: %v", err)
+	assert.Equal(t, 1, value)
+}
+
+func assertUserNotRegisteredInRoom(
+	t *testing.T, conn db.Connection, user uuid.UUID, room uuid.UUID,
+) {
+	value, err := db.QueryOne[int](
+		context.Background(),
+		conn,
+		"SELECT COUNT(*) FROM room_user WHERE chat_user = $1 AND room = $2",
+		user,
+		room,
+	)
+	assert.Nil(t, err, "Actual err: %v", err)
+	assert.Equal(t, 0, value)
+}

--- a/pkg/repositories/user_repository.go
+++ b/pkg/repositories/user_repository.go
@@ -9,7 +9,7 @@ import (
 )
 
 type UserRepository interface {
-	Create(ctx context.Context, user persistence.User) (persistence.User, error)
+	Create(ctx context.Context, tx db.Transaction, user persistence.User) (persistence.User, error)
 	Get(ctx context.Context, id uuid.UUID) (persistence.User, error)
 	GetByName(ctx context.Context, name string) (persistence.User, error)
 	ListForRoom(ctx context.Context, room uuid.UUID) ([]persistence.User, error)
@@ -32,11 +32,11 @@ INSERT INTO chat_user (id, name, api_user)
 	RETURNING created_at, updated_at`
 
 func (r *userRepositoryImpl) Create(
-	ctx context.Context, user persistence.User,
+	ctx context.Context, tx db.Transaction, user persistence.User,
 ) (persistence.User, error) {
-	times, err := db.QueryOne[createdAtUpdatedAt](
+	times, err := db.QueryOneTx[createdAtUpdatedAt](
 		ctx,
-		r.conn,
+		tx,
 		createUserSqlTemplate,
 		user.Id,
 		user.Name,


### PR DESCRIPTION
# Work

Currently when users are created they are not belonging to any room. In order to make the chat a bit friendlier this PR automatically registers them in a default room called `general`. Everybody will be in there.

The goal is two-fold:
* allow the test website to automatically display something
* test the sending/receiving of messages easily

The main changes include:
* new methods in the public `RoomRepository` interface to support interacting with the `room_user` table
* automatic registration of users to the `general` room upon creation
* automatic removal of users from the `general` room upon deletion
* modification of the user `Create` function to specify a transaction: this allows to create the user and register it in one go guaranteeing data consistency

# Tests

Some tests were added to verify the logic. Specifically in:
* `room_repository_test` to verify the new functions
* `user_service_test` to verify the new logic of registration/removal

Additionally some tests were updated to accommodate for the need to provide a transaction when creating a user.

In combination with the website, we can see that when a new user is created:

![image](https://github.com/user-attachments/assets/f197e200-813c-49bd-8a02-bb795945758c)

It lands on the `General` room:

![image](https://github.com/user-attachments/assets/8417d03b-8b75-46b1-a974-a9a4d3fa4a2c)

# Future work

N/A.