### PR TITLE
feat: Added new client manager implementation

### DIFF
--- a/cmd/chat-server/internal/http_server_test.go
+++ b/cmd/chat-server/internal/http_server_test.go
@@ -284,14 +284,8 @@ func newTestHttpProps(
 	log := logger.New(os.Stdout)
 	repos := repositories.New(dbConn)
 
-	managerProps := clients.ManagerProps{
-		Queue:     nil,
-		Handshake: nil,
-		Log:       log,
-	}
-	manager := clients.NewClientManager(managerProps)
-
-	processor := messages.NewMessageProcessor(1, manager, repos)
+	clientManager := clients.NewManager()
+	processor := messages.NewMessageProcessor(1, clientManager, repos)
 
 	props := HttpServerProps{
 		Config: conf,
@@ -301,6 +295,7 @@ func newTestHttpProps(
 			dbConn,
 			repos,
 			processor,
+			clientManager,
 			log,
 		),
 		Log: log,

--- a/cmd/chat-server/internal/server.go
+++ b/cmd/chat-server/internal/server.go
@@ -21,7 +21,8 @@ func RunServer(ctx context.Context, config Configuration, log logger.Logger) err
 
 	repos := repositories.New(dbConn)
 	// TODO: Correctly setup the message processor
-	services := service.New(config.ConnectTimeout, dbConn, repos, nil, log)
+	// TODO: Correctly setup the client manager
+	services := service.New(config.ConnectTimeout, dbConn, repos, nil, nil, log)
 
 	var tcpErr error
 	var wg sync.WaitGroup

--- a/internal/controller/chats_test.go
+++ b/internal/controller/chats_test.go
@@ -117,7 +117,8 @@ func newTestMessageService(
 	t *testing.T,
 ) (service.MessageService, db.Connection) {
 	dbConn := newTestDbConnection(t)
-	return service.NewMessageService(dbConn, &mockProcessor{}), dbConn
+	// TODO: Correctly setup the client manager
+	return service.NewMessageService(dbConn, &mockProcessor{}, nil), dbConn
 }
 
 type mockProcessor struct{}

--- a/internal/service/message_service.go
+++ b/internal/service/message_service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/Knoblauchpilze/backend-toolkit/pkg/db"
 	"github.com/Knoblauchpilze/backend-toolkit/pkg/errors"
@@ -22,12 +23,18 @@ type messageServiceImpl struct {
 	conn db.Connection
 
 	processor messages.Processor
+	manager   clients.Manager
 }
 
-func NewMessageService(conn db.Connection, processor messages.Processor) MessageService {
+func NewMessageService(
+	conn db.Connection,
+	processor messages.Processor,
+	manager clients.Manager,
+) MessageService {
 	return &messageServiceImpl{
 		conn:      conn,
 		processor: processor,
+		manager:   manager,
 	}
 }
 
@@ -51,20 +58,29 @@ func (s *messageServiceImpl) ServeClient(
 	// TODO: We could add some ping/pong mechanism. This could serve as a base
 	// for idle checking
 	// TODO: Make the message queue's size configurable
-	c, err := clients.New(1, user, response)
+	client, err := clients.New(1, user, response)
 	if err != nil {
 		return err
 	}
 
-	// TODO: Register the client in the manager
+	fmt.Printf("connecting %s\n", user)
+	if err := s.manager.OnConnect(user, client); err != nil {
+		return err
+	}
 
-	done := process.SafeRunAsync(c.Start)
+	fmt.Printf("starting %s\n", user)
+	done := process.SafeRunAsync(client.Start)
 
 	select {
 	case <-ctx.Done():
-		err = c.Stop()
+		err = client.Stop()
+		fmt.Printf("done, err: %v\n", err)
 	case err = <-done:
+		fmt.Printf("client failed, err: %v\n", err)
 	}
+
+	fmt.Printf("disconnecting: %s (err: %v)\n", user, err)
+	s.manager.OnDisconnect(user)
 
 	return err
 }

--- a/internal/service/services.go
+++ b/internal/service/services.go
@@ -22,12 +22,13 @@ func New(
 	conn db.Connection,
 	repos repositories.Repositories,
 	processor messages.Processor,
+	manager clients.Manager,
 	log logger.Logger,
 ) Services {
 	return Services{
 		Room:    NewRoomService(conn, repos),
 		User:    NewUserService(conn, repos),
-		Message: NewMessageService(conn, processor),
+		Message: NewMessageService(conn, processor, manager),
 		Chat: NewChatService(
 			clients.NewHandshake(repos.User, connectTimeout),
 			log,

--- a/pkg/clients/client.go
+++ b/pkg/clients/client.go
@@ -53,6 +53,7 @@ func generateMessageCallback(rw http.ResponseWriter) messages.MessageCallback {
 
 		// TODO: We should probably have some synchronization mechanism here.
 		// Or at least check if this is already handled.
+		fmt.Printf("sending message to socket: %+v\n", msg)
 		err = e.send(rw)
 		if err != nil {
 			return errors.WrapCode(err, ErrSseStreamFailed)

--- a/pkg/clients/client_manager.go
+++ b/pkg/clients/client_manager.go
@@ -15,7 +15,7 @@ type ClientManager interface {
 	OnDisconnect(id uuid.UUID)
 	OnReadError(id uuid.UUID, err error)
 
-	messages.Dispatcher
+	messages.MessageDispatcher
 }
 
 type clientManagerImpl struct {

--- a/pkg/messages/dispatcher.go
+++ b/pkg/messages/dispatcher.go
@@ -1,10 +1,18 @@
 package messages
 
-import "github.com/google/uuid"
+import (
+	"github.com/Knoblauchpilze/chat-server/pkg/persistence"
+	"github.com/google/uuid"
+)
 
-type Dispatcher interface {
-	// TODO: This should be using communication.MessageResponseDto
+type MessageDispatcher interface {
 	Broadcast(msg Message)
 	BroadcastExcept(id uuid.UUID, msg Message)
 	SendTo(id uuid.UUID, msg Message)
+}
+
+type Dispatcher interface {
+	Broadcast(msg persistence.Message)
+	BroadcastExcept(id uuid.UUID, msg persistence.Message)
+	SendTo(id uuid.UUID, msg persistence.Message)
 }

--- a/pkg/messages/message_processor.go
+++ b/pkg/messages/message_processor.go
@@ -2,6 +2,7 @@ package messages
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/Knoblauchpilze/chat-server/pkg/persistence"
 	"github.com/Knoblauchpilze/chat-server/pkg/repositories"
@@ -29,8 +30,10 @@ func generateMessageCallback(
 			return err
 		}
 
-		out := NewRoomMessage(msg.ChatUser, msg.Room, msg.Message)
-		dispatcher.BroadcastExcept(msg.ChatUser, out)
+		fmt.Printf("received message: %+v (err: %v)\n", msg, err)
+
+		fmt.Printf("broadcasting except to %s\n", msg.ChatUser)
+		dispatcher.BroadcastExcept(msg.ChatUser, msg)
 
 		return nil
 	}

--- a/pkg/messages/message_processor_test.go
+++ b/pkg/messages/message_processor_test.go
@@ -61,15 +61,7 @@ func TestIT_MessageProcessor_EnqueueMessage_ExpectSentToDispatcher(t *testing.T)
 	wg.Wait()
 
 	assert.Equal(t, user.Id, mock.receivedId)
-	assert.Equal(t, ROOM_MESSAGE, mock.receivedMsg.Type())
-	actual, err := ToMessageStruct[RoomMessage](mock.receivedMsg)
-	assert.Nil(t, err, "Actual err: %v", err)
-	expectedMessage := RoomMessage{
-		Emitter: user.Id,
-		Room:    room.Id,
-		Content: msg.Message,
-	}
-	assert.Equal(t, expectedMessage, actual)
+	assert.Equal(t, msg, mock.receivedMsg)
 }
 
 func TestIT_MessageProcessor_WhenMessageFailsToBeWritten_ExpectProcessingStops(t *testing.T) {
@@ -105,19 +97,19 @@ func newTestMessageProcessor(t *testing.T) (Processor, db.Connection, *mockDispa
 
 type mockDispatcher struct {
 	receivedId  uuid.UUID
-	receivedMsg Message
+	receivedMsg persistence.Message
 }
 
-func (m *mockDispatcher) Broadcast(msg Message) {
+func (m *mockDispatcher) Broadcast(msg persistence.Message) {
 	m.receivedMsg = msg
 }
 
-func (m *mockDispatcher) BroadcastExcept(id uuid.UUID, msg Message) {
+func (m *mockDispatcher) BroadcastExcept(id uuid.UUID, msg persistence.Message) {
 	m.receivedId = id
 	m.receivedMsg = msg
 }
 
-func (m *mockDispatcher) SendTo(id uuid.UUID, msg Message) {
+func (m *mockDispatcher) SendTo(id uuid.UUID, msg persistence.Message) {
 	m.receivedId = id
 	m.receivedMsg = msg
 }

--- a/pkg/messages/processing_service.go
+++ b/pkg/messages/processing_service.go
@@ -17,7 +17,7 @@ const timeoutForMessageProcessing = 1 * time.Second
 
 type processingServiceImpl struct {
 	queue      IncomingQueue
-	dispatcher Dispatcher
+	dispatcher MessageDispatcher
 
 	log logger.Logger
 
@@ -27,7 +27,7 @@ type processingServiceImpl struct {
 
 func NewProcessingService(
 	queue IncomingQueue,
-	dispatcher Dispatcher,
+	dispatcher MessageDispatcher,
 	log logger.Logger,
 ) ProcessingService {
 	return &processingServiceImpl{

--- a/pkg/messages/processing_service_test.go
+++ b/pkg/messages/processing_service_test.go
@@ -14,7 +14,7 @@ import (
 const reasonableWaitTimeForServiceToBeUp = 50 * time.Millisecond
 
 type dispatcherMock struct {
-	Dispatcher
+	MessageDispatcher
 
 	broadcastMsgs       []Message
 	broadcastExceptMsgs []Message
@@ -25,7 +25,7 @@ type dispatcherMock struct {
 
 func TestUnit_ProcessingService_StartStop(t *testing.T) {
 	var queue IncomingQueue
-	var manager Dispatcher
+	var manager MessageDispatcher
 	service := NewProcessingService(queue, manager, logger.New(os.Stdout))
 
 	wg := asyncRunProcessingService(t, service)


### PR DESCRIPTION
# Work

Currently the new SSE implementation does not have a concept of a `ClientManager` similar to what is proposed by the TCP implementation. This is a problem because it prevents proper broadcasting of messages. In this PR, we address this problem by adding such an implementation

## The problem statement

Currently the `clients.ClientManager` The existing interface looks like so:

```go
type ClientManager interface {
	OnConnect(conn net.Conn) (bool, uuid.UUID)
	OnDisconnect(id uuid.UUID)
	OnReadError(id uuid.UUID, err error)

	messages.Dispatcher
}
```

The main disadvantages are:
* it is quite tied to the callbacks logic needed for TCP connections management
* it embeds the `messages.Dispatcher` interface which is also not very suited to the new logic

The second point is quite cumbersome to deal with because the logic to post messages in the SSE mode is the following:
* the client posts a message using a POST HTTP request: from there we get a `communication.MessageDtoRequest`
* we convert this to a `persistence.Message`
* we need to change it to a `messages.Message` to use the `Dispatcher` interface
* the `Client` expects to send back a `communication.MessageDtoResponse`

As the `messages.Message` does not have a notion of an identifier, we lose this information along the way.

## How to fix this?

To fix this, we already prepared some ground work in [6db634b](https://github.com/Knoblauchpilze/chat-server/commit/6db634b4a2722d81c3f1af21076df3d2984efbd1) where we renamed `clients.Manager` to `clients.ClientManager`: this clears up the path to have a new `clients.Manager`. In this PR we move the existing `messages.Dispatcher` to `messages.MessageDispatcher` and make the new interface live under `messages.Dispatcher`.

The new interface takes `persistence.Message` as arguments and allow smoother flowing of messages through our system.

The client manager implementation in itself is also more straightforward:
* there's no manipulation connection anymore
* broadcasting a message is just about pushing it to the queues of each client (which implement the `messages.Processor` interface)

Connection and disconnection handling is also simpler as it is just about registering/deregistering from the internal map.

## Use in the `MessageService`

The `clients.Manager` is provided as an input argument of the construction of the `MessageService`. Upon calling `ServeClient` we register it in the manager and deregister it if the request ends or if an error occurs.

# Tests

Tests were adapted when needed and created when necessary. Specifically:
* updated tests in `client_manager_test.go` to reflect the new `messages.Dispatcher` interface
* updated mocks in modules where a `messages.Dispatcher` was used
* added integration tests for the `MessageService`

# Future work

There are a bunch of TODOs left to be tackled. Additionally we need to remove the old interfaces when we switched to the new SSE approach.